### PR TITLE
Update example to match available options

### DIFF
--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -17,9 +17,9 @@ usage:
             snyk-scan: true
             snyk-threshold: high
             snyk-fail-build: false
-        - hmpps/deploy_to_env:
+        - hmpps/deploy_env:
             name: deploy_dev
             env: "dev"
-            app_name: "example_app"
+            chart_name: "example_app"
             requires:
               - build_docker


### PR DESCRIPTION
`deploy_to_env` doesn't exist, the job name is `deploy_env`
`app_name` is not a valid parameter, use `chart_name`