### PR TITLE
[semver:major] Upgrade Slack to notify on failed deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,11 +74,11 @@ workflows:
       # your integration test jobs go here: essentially, run all your orb's
       # jobs and commands to ensure they behave as expected. or, run other
       # integration tests of your choosing
-       
+
       # Add any test for orb commands to this job
       - integration-tests-orb-commands
 
-      # Add test for orb jobs below 
+      # Add test for orb jobs below
       - hmpps/build_docker:
           image_name: example_image_name
           publish: false
@@ -98,8 +98,12 @@ workflows:
           helm_dir: tests/helm_deploy
           helm_additional_args: "--dry-run --debug"
           retrieve_secrets: "none"
+          slack_notification: true
+          slack_channel_name: test
           requires:
             - hmpps/build_docker
+          context:
+            - moj-slack-notifications
 
       # publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
@@ -119,4 +123,3 @@ workflows:
           filters:
             branches:
               only: master
-

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -13,6 +13,5 @@ orbs:
   aws-cli: circleci/aws-cli@1.2.1
   kubernetes: circleci/kubernetes@0.11.0
   helm: circleci/helm@1.0.0
-  slack: circleci/slack@3.4.2
+  slack: circleci/slack@4.1.3
   snyk: snyk/snyk@0.0.10
-

--- a/src/examples/slack_notification.yml
+++ b/src/examples/slack_notification.yml
@@ -1,0 +1,24 @@
+---
+description: >
+  Deployment with Slack notifications
+usage:
+  version: 2.1
+  orbs:
+    hmpps: ministryofjustice/hmpps@2.0.0
+  workflows:
+    build-test-and-deploy:
+      jobs:
+        - hmpps/build_docker:
+            name: build_docker
+            image_name: example_image_name
+            snyk-scan: true
+            snyk-threshold: high
+        - hmpps/deploy_env:
+            name: deploy_dev
+            env: "dev"
+            slack_notification: true
+            slack_channel_name: your-notification-channel
+            context:
+              - moj-slack-notifications
+            requires:
+              - build_docker

--- a/src/jobs/deploy_env.yml
+++ b/src/jobs/deploy_env.yml
@@ -19,6 +19,11 @@ parameters:
   slack_notification:
     type: boolean
     default: false
+    description: When true, notifies a Slack channel after every deployment done with this job.
+  slack_channel_name:
+    type: string
+    default: dps-releases
+    description: Slack channel to use for deployment notifications.
   helm_additional_args:
     type: string
     default: ""
@@ -57,6 +62,34 @@ steps:
       condition: <<parameters.slack_notification>>
       steps:
         - slack/notify:
-            message: "*<< parameters.release_name >>* version:*${APP_VERSION}* deployed to << parameters.env >>"
-            include_project_field: false
-            include_job_number_field: false
+            event: always
+            channel: << parameters.slack_channel_name >>
+            custom: |
+              {
+                "blocks": [
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "mrkdwn",
+                        "text": ":circleci-${CCI_STATUS}: CircleCI deploy ${CCI_STATUS}"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*<< parameters.release_name >>* version `${APP_VERSION}` deploy to _<< parameters.env >>_"
+                    },
+                    "accessory": {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View job"
+                      },
+                      "url": "$CIRCLE_BUILD_URL"
+                    }
+                  }
+                ]
+              }


### PR DESCRIPTION
With the current configuration, we only get Slack notifications about
successful deployments, despite having the notification steps in the
compiled CircleCI steps.

This is an attempt to enable notifications for all cases.

As part of this upgrade, Slack configuration needs to change.

- **old** `SLACK_WEBHOOK_URL`
- **new** `SLACK_ACCESS_TOKEN` through `moj-slack-notifications` context

Slack orb 4+ requires an application to be set up and a
`SLACK_ACCESS_TOKEN` variable. To enable this, we've installed an app
called `ci-deploy-to-cloud-platform` on the MoJ Slack instance.

The token is shared in the `moj-slack-notifications` CircleCI context.
Please see [the example notification workflow][ex] for a usage example.

[ex]: https://github.com/sldblog/hmpps-circleci-orb/blob/17f0802388332e3e9ddda7c9561b102ec5020868/src/examples/slack_notification.yml

----

Is it possible to push a dev/alpha version up from this so I can test it out in a project?