### PR TITLE
[semver:major] Upgrade Slack to notify on failed deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ workflows:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
       - orb-tools/lint # Lint Yaml files
+          lint-dir: "src"
       - orb-tools/pack # Pack orb source
       # Publish development version(s) of the orb.
       - orb-tools/publish-dev:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,26 @@
 version: 2.1
 
-# add your orb below, to be used in integration tests (note: a @dev:alpha
-# release must exist.);
 orbs:
   hmpps: ministryofjustice/hmpps@<<pipeline.parameters.dev-orb-version>>
-  orb-tools: circleci/orb-tools@9.1.0
+  orb-tools: circleci/orb-tools@10.0
 
-# Pipeline parameters
+# Pipeline Parameters
+## These parameters are used internally by orb-tools. Skip to the Jobs section.
 parameters:
-  # These pipeline parameters are required by the "trigger-integration-tests-workflow"
-  # job, by default.
   run-integration-tests:
+    description: An internal flag to prevent integration test from running before a development version has been created.
     type: boolean
     default: false
   dev-orb-version:
+    description: >
+      The development version of the orb to test.
+      This value is automatically adjusted by the "trigger-integration-tests-workflow" job to correspond with the specific version created by the commit and should not be edited.
+      A "dev:alpha" version must exist for the initial pipeline run.
     type: string
     default: "dev:alpha"
 
 jobs:
-  # This job is an example of an integration testing job.
-  # This job should execute a command from your orb and verify
-  # the output is as expected, otherwise the job should fail.
-  #
-  # Rename this job and add more as needed.
-  #
-
+  # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
   integration-tests-orb-commands:
     executor: orb-tools/ubuntu
     steps:
@@ -34,48 +30,34 @@ jobs:
       - hmpps/install_aws_cli
 
 workflows:
-  # This `lint-pack_validate_publish-dev` workflow will run on any commit.
-  lint_pack-validate_publish-dev:
+  # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
+  # This workflow will run on every commit
+  test-pack:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - orb-tools/lint:
-          lint-dir: "src"
-      # pack your orb YAML files to a single orb.yml
-      # validate the orb.yml file to ensure it is well-formed
-      - orb-tools/pack:
-          requires:
-            - orb-tools/lint
-
-      # release dev version of orb, for testing & possible publishing.
-      # orb will be published as dev:alpha and dev:${CIRCLE_SHA1:0:7}.
-      # requires a CircleCI API token to be stored as CIRCLE_TOKEN (default)
-      # https://circleci.com/docs/2.0/managing-api-tokens
-      # store CIRCLE_TOKEN as a project env var or Contexts resource
-      # if using Contexts, add your context below
+      - orb-tools/lint # Lint Yaml files
+      - orb-tools/pack # Pack orb source
+      # Publish development version(s) of the orb.
       - orb-tools/publish-dev:
           orb-name: ministryofjustice/hmpps
           requires:
             - orb-tools/pack
 
-      # trigger an integration workflow to test the
+      # Trigger an integration workflow to test the
       # dev:${CIRCLE_SHA1:0:7} version of your orb
       - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev
           requires:
             - orb-tools/publish-dev
 
-  # This `integration-tests_prod-release` workflow will only run
+  # This `integration-test_deploy` workflow will only run
   # when the run-integration-tests pipeline parameter is set to true.
   # It is meant to be triggered by the "trigger-integration-tests-workflow"
   # job, and run tests on <your orb>@dev:${CIRCLE_SHA1:0:7}.
-  integration-tests_prod-release:
+  integration-test_deploy:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
-      # your integration test jobs go here: essentially, run all your orb's
-      # jobs and commands to ensure they behave as expected. or, run other
-      # integration tests of your choosing
-
-      # Add any test for orb commands to this job
+      # Run any integration tests defined within the `jobs` key.
       - integration-tests-orb-commands
 
       # Add test for orb jobs below
@@ -99,7 +81,7 @@ workflows:
           helm_additional_args: "--dry-run --debug"
           retrieve_secrets: "none"
           slack_notification: true
-          slack_channel_name: test
+          slack_channel_name: dps_alerts_non_prod
           requires:
             - hmpps/build_docker
           context:
@@ -115,9 +97,10 @@ workflows:
           orb-name: ministryofjustice/hmpps
 
           add-pr-comment: false
-          fail-if-semver-not-indicated: false
+          fail-if-semver-not-indicated: true
           publish-version-tag: false
           requires:
+            - integration-tests-orb-commands
             - hmpps/build_docker
             - hmpps/deploy_env
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ parameters:
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
   integration-tests-orb-commands:
-    executor: orb-tools/ubuntu
+    docker:
+      - image: cimg/base:stable
     steps:
       - hmpps/create_app_version
       - hmpps/k8s_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ workflows:
   test-pack:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - orb-tools/lint # Lint Yaml files
+      - orb-tools/lint: # Lint Yaml files
           lint-dir: "src"
       - orb-tools/pack # Pack orb source
       # Publish development version(s) of the orb.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,11 +74,11 @@ workflows:
       # your integration test jobs go here: essentially, run all your orb's
       # jobs and commands to ensure they behave as expected. or, run other
       # integration tests of your choosing
-       
+
       # Add any test for orb commands to this job
       - integration-tests-orb-commands
 
-      # Add test for orb jobs below 
+      # Add test for orb jobs below
       - hmpps/build_docker:
           image_name: example_image_name
           publish: false
@@ -98,8 +98,12 @@ workflows:
           helm_dir: tests/helm_deploy
           helm_additional_args: "--dry-run --debug"
           retrieve_secrets: "none"
+          slack_notification: true
+          slack_channel_name: test
           requires:
             - hmpps/build_docker
+          context:
+            - moj-slack-notifications
 
       # publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
@@ -119,4 +123,3 @@ workflows:
           filters:
             branches:
               only: master
-

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The dev version of ministryofjustice/hmpps@dev:alpha has expired. Dev versions o
 If you see this error, you need to publish a dev:alpha version manually. The fix is to run this:
 
 ```
+circleci orb pack ./src | circleci orb validate -
 circleci config pack ./src | circleci orb publish -  ministryofjustice/hmpps@dev:alpha
 ```
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -13,6 +13,5 @@ orbs:
   aws-cli: circleci/aws-cli@1.2.1
   kubernetes: circleci/kubernetes@0.11.0
   helm: circleci/helm@1.0.0
-  slack: circleci/slack@3.4.2
+  slack: circleci/slack@4.1.3
   snyk: snyk/snyk@0.0.10
-

--- a/src/examples/slack_notification.yml
+++ b/src/examples/slack_notification.yml
@@ -1,0 +1,24 @@
+---
+description: >
+  Deployment with Slack notifications
+usage:
+  version: 2.1
+  orbs:
+    hmpps: ministryofjustice/hmpps@2.0.0
+  workflows:
+    build-test-and-deploy:
+      jobs:
+        - hmpps/build_docker:
+            name: build_docker
+            image_name: example_image_name
+            snyk-scan: true
+            snyk-threshold: high
+        - hmpps/deploy_env:
+            name: deploy_dev
+            env: "dev"
+            slack_notification: true
+            slack_channel_name: your-notification-channel
+            context:
+              - moj-slack-notifications
+            requires:
+              - build_docker

--- a/src/jobs/deploy_env.yml
+++ b/src/jobs/deploy_env.yml
@@ -19,6 +19,11 @@ parameters:
   slack_notification:
     type: boolean
     default: false
+    description: When true, notifies a Slack channel after every deployment done with this job.
+  slack_channel_name:
+    type: string
+    default: dps-releases
+    description: Slack channel to use for deployment notifications.
   helm_additional_args:
     type: string
     default: ""
@@ -57,6 +62,34 @@ steps:
       condition: <<parameters.slack_notification>>
       steps:
         - slack/notify:
-            message: "*<< parameters.release_name >>* version:*${APP_VERSION}* deployed to << parameters.env >>"
-            include_project_field: false
-            include_job_number_field: false
+            event: always
+            channel: << parameters.slack_channel_name >>
+            custom: |
+              {
+                "blocks": [
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "mrkdwn",
+                        "text": ":circleci-${CCI_STATUS}: CircleCI deploy ${CCI_STATUS}"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*<< parameters.release_name >>* version `${APP_VERSION}` deploy to _<< parameters.env >>_"
+                    },
+                    "accessory": {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View job"
+                      },
+                      "url": "$CIRCLE_BUILD_URL"
+                    }
+                  }
+                ]
+              }


### PR DESCRIPTION
With the current configuration, we only get Slack notifications about
successful deployments, despite having the notification steps in the
compiled CircleCI steps.

This is an attempt to enable notifications for all cases.

As part of this upgrade, Slack configuration needs to change.

- **old** `SLACK_WEBHOOK_URL`
- **new** `SLACK_ACCESS_TOKEN` through `moj-slack-notifications` context

Slack orb 4+ requires an application to be set up and a
`SLACK_ACCESS_TOKEN` variable. To enable this, we've installed an app
called `ci-deploy-to-cloud-platform` on the MoJ Slack instance.

The token is shared in the `moj-slack-notifications` CircleCI context.
Please see [the example notification workflow][ex] for a usage example.

[ex]: src/examples/slack_notification.yml