### PR TITLE
[semver:minor] Update to cimg circle images and avoid re-installing latest npm in the npm_security_audit job

### DIFF
--- a/src/executors/node.yml
+++ b/src/executors/node.yml
@@ -2,9 +2,9 @@
 description: >
   Default executor for node.js jobs
 docker:
-  - image: 'circleci/node:<<parameters.tag>>'
+  - image: 'cimg/node:<<parameters.tag>>'
 working_directory: ~/app
 parameters:
   tag:
-    default: "10-buster-browsers"
+    default: "10-browsers"
     type: string

--- a/src/executors/node.yml
+++ b/src/executors/node.yml
@@ -6,5 +6,5 @@ docker:
 working_directory: ~/app
 parameters:
   tag:
-    default: "10-browsers"
+    default: "10.23-browsers"
     type: string

--- a/src/jobs/npm_security_audit.yml
+++ b/src/jobs/npm_security_audit.yml
@@ -4,9 +4,6 @@ description: >
 executor: node
 steps:
   - checkout
-  - run:
-      name: update-npm
-      command: 'sudo npm install -g npm'
   - restore_cache:
       key: dependency-cache-{{ checksum "package.json" }}
   - run:


### PR DESCRIPTION
* Updates the default node image to use the cimg/ circle images in place of circleci/ images.
* Avoids a re-install of npm:latest in the npm_security_audit job as npm and yarn are pre-installed in the cimg/ images

This is to resolve the failing npm_security_job across the node applications due to it installing npm v7.5.2 (latest) regardless of the node image being used, which subsequently fails attempting to install the audit-ci package.