### PR TITLE
[semver:patch] Always pull base image on builds

### DIFF
--- a/src/jobs/build_docker.yml
+++ b/src/jobs/build_docker.yml
@@ -40,7 +40,8 @@ steps:
       name: Build container image
       command: |
         IMAGE_NAME="<< parameters.image_name >>"
-        docker build --rm=false << parameters.dockerfile_dir >> \
+        docker build --pull \
+          --rm=false << parameters.dockerfile_dir >> \
           --build-arg BUILD_NUMBER=$APP_VERSION \
           --build-arg GIT_REF=$CIRCLE_SHA1 \
           --tag "<< parameters.image_name >>:${APP_VERSION}" \


### PR DESCRIPTION
We ran into some cases where the image build used yesterday's base image
and it tripped our vulnerability scanning.

Since we knew it was fixed already, it was a stale image. To avoid, we
can now pull the base image every time: if it's up-to-date, great,
otherwise it must contain something meaningful.

Overall, it makes the build more predictable.