### PR TITLE
Allow the built docker container to be used in subsequent jobs.

### DIFF
--- a/src/commands/recall_container_image.yml
+++ b/src/commands/recall_container_image.yml
@@ -1,0 +1,18 @@
+---
+description: >
+  Recalls the built container image (tagged as "${IMAGE_NAME}:${APP_VERSION}"
+  in the environment) within the circleci workspace so that it can be used in
+  a subsequent job.
+
+  NOTE: You MUST have ran your `build_docker` job with the parameter
+  `persist_container_image` set to `true`.
+steps:
+  - attach_workspace:
+      at: ~/app
+  - run:
+      name: Extract saved container image
+      command: docker load --input docker_cache/build_image.tar
+  - mem/recall:
+      env_var: IMAGE_NAME
+  - mem/recall:
+      env_var: APP_VERSION

--- a/src/jobs/build_docker.yml
+++ b/src/jobs/build_docker.yml
@@ -12,6 +12,10 @@ parameters:
   publish:
     type: boolean
     default: true
+  persist_container_image:
+    type: boolean
+    default: false
+    description: Make the built container image available for subsequent jobs
   snyk-scan:
     type: boolean
     default: false
@@ -37,14 +41,21 @@ steps:
       docker_layer_caching: true
   - create_app_version
   - run:
-      name: Build container image
+      name: Create IMAGE_NAME env var
       command: |
         IMAGE_NAME="<< parameters.image_name >>"
+        echo "export IMAGE_NAME=$IMAGE_NAME" >> $BASH_ENV
+  - mem/remember:
+      env_var: IMAGE_NAME
+      value: "${IMAGE_NAME}"
+  - run:
+      name: Build container image
+      command: |
         docker build --pull \
           --rm=false << parameters.dockerfile_dir >> \
           --build-arg BUILD_NUMBER=$APP_VERSION \
           --build-arg GIT_REF=$CIRCLE_SHA1 \
-          --tag "<< parameters.image_name >>:${APP_VERSION}" \
+          --tag "${IMAGE_NAME}:${APP_VERSION}" \
           --label "maintainer=dps-hmpps@digital.justice.gov.uk" \
           --label "app.version=${APP_VERSION}" \
           --label "build.version=${APP_VERSION}" \
@@ -53,12 +64,25 @@ steps:
           --label "build.gitref=${CIRCLE_SHA1}"
 
   - when:
+      condition: << parameters.persist_container_image >>
+      steps:
+        - run:
+            name: Persist container image to workspace
+            command: |
+              mkdir -p docker_cache
+              docker save ${IMAGE_NAME}:${APP_VERSION} -o docker_cache/build_image.tar
+        - persist_to_workspace:
+            root: ~/app
+            paths:
+              - docker_cache
+
+  - when:
       condition: << parameters.snyk-scan >>
       steps:
         - snyk/scan:
             project: "${CIRCLE_PROJECT_REPONAME}-docker"
             organization: << parameters.snyk-org >>
-            docker-image-name: "<< parameters.image_name >>:$APP_VERSION"
+            docker-image-name: "${IMAGE_NAME}:${APP_VERSION}"
             target-file: << parameters.dockerfile_dir >>/<< parameters.snyk-target-file >>
             severity-threshold: << parameters.snyk-threshold >>
             fail-on-issues: << parameters.snyk-fail-build >>

--- a/src/jobs/publish_docker.yml
+++ b/src/jobs/publish_docker.yml
@@ -1,0 +1,29 @@
+---
+description: >
+  Pushes the built container image to the repository.
+
+  NOTE: You MUST have ran your `build_docker` job with the parameter
+  `persist_container_image` set to `true`.
+executor: default_small
+parameters:
+  publish_latest_tag:
+    type: boolean
+    default: true
+steps:
+  - checkout
+  - setup_remote_docker
+  - recall_container_image
+  - run:
+      name: Publish image to repository
+      command: |
+        docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io
+        docker push "${IMAGE_NAME}:${APP_VERSION}"
+
+  - when:
+      condition: << parameters.publish_latest_tag >>
+      steps:
+        - run:
+            name: Publish `latest` tag to repository
+            command: |
+              docker tag "${IMAGE_NAME}:${APP_VERSION}" "${IMAGE_NAME}:latest"
+              docker push "${IMAGE_NAME}:latest"


### PR DESCRIPTION
This allows the built container image to be saved to the workspace and
recalled in subsequent jobs, meaning that you can build your container,
use it in several other jobs (i.e. CVE scanning, tests etc) without
having to publish it to the container repository first.

As a result, I've also introduced a separate `publish_docker` job here
too.