### PR TITLE
[semver:minor] Add jobs to scan the container images with Trivy

### DIFF
--- a/src/commands/install_trivy.yml
+++ b/src/commands/install_trivy.yml
@@ -1,0 +1,7 @@
+---
+description: Install Trivy
+steps:
+  - run:
+      name: Install Trivy
+      command: |
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp

--- a/src/jobs/trivy_latest_scan.yml
+++ b/src/jobs/trivy_latest_scan.yml
@@ -1,0 +1,65 @@
+---
+description: >
+  Scan the latest tag (docker container image) for CVEs using Trivy.
+
+  This is intended to be a scheduled job that runs maybe daily and can
+  alert teams to new found issues on running applications that might not
+  be in active development.
+executor: default
+parameters:
+  image_name:
+    type: string
+    default: "quay.io/hmpps/${CIRCLE_PROJECT_REPONAME}"
+  cve_severities_to_check:
+    type: string
+    default: HIGH,CRITICAL
+    description: What severity of CVE to look for? Options are UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL.
+  slack_channel:
+    type: string
+    default: dps_alerts_security
+    description: Slack channel to use for notifications.
+steps:
+  - checkout
+  - setup_remote_docker
+  - install_trivy
+  - run:
+      name: Trivy scan for << parameters.cve_severities_to_check >> CVEs
+      command: |
+        /tmp/trivy image \
+          --exit-code 100 \
+          --no-progress \
+          --severity << parameters.cve_severities_to_check >> \
+          --ignore-unfixed \
+          "<< parameters.image_name >>:latest"
+  - slack/notify:
+      event: fail
+      channel: << parameters.slack_channel >>
+      custom: |
+        {
+          "blocks": [
+            {
+              "type": "context",
+              "elements": [
+                {
+                  "type": "mrkdwn",
+                  "text": ":circleci-${CCI_STATUS}: CircleCI job *${CIRCLE_JOB}* ${CCI_STATUS}"
+                }
+              ]
+            },
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "*${CIRCLE_PROJECT_REPONAME}* failed ${CIRCLE_JOB}"
+              },
+              "accessory": {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "text": "View job"
+                },
+                "url": "${CIRCLE_BUILD_URL}"
+              }
+            }
+          ]
+        }

--- a/src/jobs/trivy_pipeline_scan.yml
+++ b/src/jobs/trivy_pipeline_scan.yml
@@ -1,0 +1,33 @@
+---
+description: >
+  Scan the built docker container for CVEs using Trivy.
+executor: default
+parameters:
+  fail_build:
+    type: boolean
+    default: true
+    description: Fail the build if any CVEs are detected.
+  cve_severities_to_check:
+    type: string
+    default: HIGH,CRITICAL
+    description: What severity of CVE to look for? Options are UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL.
+steps:
+  - checkout
+  - setup_remote_docker
+  - recall_container_image
+  - install_trivy
+  - run:
+      name: Trivy scan for << parameters.cve_severities_to_check >> CVEs
+      command: |
+        EXIT_CODE=0
+
+        if [ "<< parameters.fail_build >>" == "true" ]; then
+          EXIT_CODE=100
+        fi
+
+        /tmp/trivy image \
+          --exit-code ${EXIT_CODE} \
+          --no-progress \
+          --severity << parameters.cve_severities_to_check >> \
+          --ignore-unfixed \
+          "${IMAGE_NAME}:${APP_VERSION}"


### PR DESCRIPTION
This adds two trivy scans, one intended to scan the built container as
part of a pipeline run, and the other as a scheduled job to scan the
`latest` tag of a project to check for CVEs that have been identified
since the last deployment/build.