### PR TITLE
[semver:minor] Deploy changelog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,8 @@ workflows:
           helm_additional_args: "--dry-run --debug"
           slack_notification: true
           slack_channel_name: dps_alerts_non_prod
+          show_changelog: true
+          fixed_previous_version: "2021-06-08.1170.fe7a8db"
           requires:
             - hmpps/build_docker
           context:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.deployment_changelog

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ circleci orb pack ./src | circleci orb publish -  ministryofjustice/hmpps@dev:al
 
 This orb is dependant on the `circleci/slack` orb. To allow slack messages to be sent, a slack app has been created as per the instructions here: <https://github.com/CircleCI-Public/slack-orb/wiki/Setup>
 
-To see the slack apps configuration go here <https://api.slack.com/apps/> and find the app called `App Releases`. From here you can find the `OAuth & Permissions` page. The access token for this app needs to be exposed as environment variable `SLACK_ACCESS_TOKEN` to the circleci job - please read the linked docs for more details. Including this environment variable can be done by including the circleci context `hmpps-common-vars` on the circleci workflow.
+To see the slack apps configuration go here <https://api.slack.com/apps/> and find the app called `HMPPS CircleCI`. From here you can find the `OAuth & Permissions` page. The access token for this app needs to be exposed as environment variable `SLACK_ACCESS_TOKEN` to the circleci job - please read the linked docs for more details. Including this environment variable can be done by including the circleci context `hmpps-common-vars` on the circleci workflow.
 
 ## Resources
 
@@ -42,4 +42,3 @@ To publish a new production version:
 * On merge, the release will be published to the orb registry automatically.
 
 For further questions/comments about this or other orbs, visit the Orb Category of [CircleCI Discuss](https://discuss.circleci.com/c/orbs).
-

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -13,7 +13,7 @@ orbs:
   aws-cli: circleci/aws-cli@1.2.1
   kubernetes: circleci/kubernetes@0.11.0
   helm: circleci/helm@1.1.2
-  slack: circleci/slack@4.3.1
+  slack: circleci/slack@4.4.2
   snyk: snyk/snyk@0.0.10
   gradle: circleci/gradle@2.2.0
   owasp: entur/owasp@0.0.15

--- a/src/examples/deployment_with_slack_and_changelog.yml
+++ b/src/examples/deployment_with_slack_and_changelog.yml
@@ -1,0 +1,25 @@
+---
+description: >
+  Deployment with Slack notifications and git changelog
+usage:
+  version: 2.1
+  orbs:
+    hmpps: ministryofjustice/hmpps@3.5
+  workflows:
+    build-test-and-deploy:
+      jobs:
+        - hmpps/build_docker:
+            name: build_docker
+            image_name: example_image_name
+            snyk-scan: true
+            snyk-threshold: high
+        - hmpps/deploy_env:
+            name: deploy_dev
+            env: "dev"
+            slack_notification: true
+            slack_channel_name: your-notification-channel
+            show_changelog: true
+            context:
+              - hmpps-common-vars
+            requires:
+              - build_docker

--- a/src/jobs/deploy_env.yml
+++ b/src/jobs/deploy_env.yml
@@ -37,7 +37,7 @@ parameters:
   show_changelog:
     type: boolean
     default: false
-    description: When true, displays what is new since the previous deployment.
+    description: When true, displays what is new since the previous deployment in the job, and in Slack, if applicable
   k8s_deployment_name:
     type: string
     default: PROJECT_NAME
@@ -45,7 +45,7 @@ parameters:
   fixed_previous_version:
     type: string
     default: ""
-    description: Instead of reading from Kubernetes deployment, provide a fixed APP_VERSION for the previous deployment
+    description: (Only used for orb integration testing) Instead of reading from Kubernetes deployment, provide a fixed APP_VERSION for the previous deployment
 steps:
   - checkout
   - k8s_setup

--- a/src/jobs/deploy_env.yml
+++ b/src/jobs/deploy_env.yml
@@ -34,6 +34,18 @@ parameters:
   helm_additional_args:
     type: string
     default: ""
+  show_changelog:
+    type: boolean
+    default: false
+    description: When true, displays what is new since the previous deployment.
+  k8s_deployment_name:
+    type: string
+    default: PROJECT_NAME
+    description: The Deployment resource's name in Kubernetes to interrogate for the previous deployment's version
+  fixed_previous_version:
+    type: string
+    default: ""
+    description: Instead of reading from Kubernetes deployment, provide a fixed APP_VERSION for the previous deployment
 steps:
   - checkout
   - k8s_setup
@@ -41,6 +53,20 @@ steps:
   - install_aws_cli
   - mem/recall:
       env_var: APP_VERSION
+  - when:
+      condition: <<parameters.show_changelog>>
+      steps:
+        - run:
+            name: Show changes about to be released on << parameters.env >>
+            environment:
+              K8S_DEPLOYMENT_NAME: << parameters.k8s_deployment_name >>
+              K8S_PREVIOUS_APP_VERSION: << parameters.fixed_previous_version >>
+            command: <<include(scripts/version_history.sh)>>
+        - run:
+            name: Store deployment changelog
+            command: |
+              DEPLOYMENT_CHANGELOG="$(<.deployment_changelog)"
+              echo "export DEPLOYMENT_CHANGELOG_JSON=$(echo -n "$DEPLOYMENT_CHANGELOG" | tr '"' "'" | jq -Rs)" >> $BASH_ENV
   - deploy:
       name: Deploy to << parameters.env >>
       working_directory: << parameters.helm_dir >>
@@ -62,15 +88,6 @@ steps:
               {
                 "blocks": [
                   {
-                    "type": "context",
-                    "elements": [
-                      {
-                        "type": "mrkdwn",
-                        "text": ":circleci-${CCI_STATUS}: CircleCI deploy ${CCI_STATUS}"
-                      }
-                    ]
-                  },
-                  {
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
@@ -84,6 +101,19 @@ steps:
                       },
                       "url": "${CIRCLE_BUILD_URL}"
                     }
+                  },
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "mrkdwn",
+                        "text": ":circleci-${CCI_STATUS}: Deploy ${CCI_STATUS}"
+                      },
+                      {
+                        "type": "plain_text",
+                        "text": "\n${DEPLOYMENT_CHANGELOG_JSON}"
+                      }
+                    ]
                   }
                 ]
               }

--- a/src/scripts/version_history.sh
+++ b/src/scripts/version_history.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$K8S_DEPLOYMENT_NAME" == "PROJECT_NAME" ]; then
+  K8S_DEPLOYMENT_NAME="$CIRCLE_PROJECT_REPONAME"
+fi
+
+if [ "$K8S_PREVIOUS_APP_VERSION" == "" ]; then
+  K8S_PREVIOUS_APP_VERSION="$(kubectl get "deployment/$K8S_DEPLOYMENT_NAME" --namespace="$KUBE_ENV_NAMESPACE" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}')"
+fi
+
+previous_commit="$(echo "$K8S_PREVIOUS_APP_VERSION" | cut -d'.' -f3)"
+current_commit="$(echo "$APP_VERSION" | cut -d'.' -f3)"
+
+PAGER="cat" git log --oneline --no-decorate \
+  --committer='noreply@github.com' --grep='#' \
+  "$previous_commit..$current_commit" \
+  > .deployment_changelog
+
+cat .deployment_changelog

--- a/src/scripts/version_history.sh
+++ b/src/scripts/version_history.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -e
+
+# ensure consequences still work if this script blows up
+touch .deployment_changelog
 
 if [ "$K8S_DEPLOYMENT_NAME" == "PROJECT_NAME" ]; then
   K8S_DEPLOYMENT_NAME="$CIRCLE_PROJECT_REPONAME"


### PR DESCRIPTION
Extend the `deploy_env` job with an opt-in flag `show_changelog`, which, when `true`, annotates the deployment notification:

<img width="680" alt="image" src="https://user-images.githubusercontent.com/1526295/123352711-d5286f00-d557-11eb-86e8-60fd6c22d75c.png">

It will build the log based on the difference of
- the last deployed version sha from the `Deployment` in the cloud platform (or technically, any Kubernetes) namespace
- and the sha in the `APP_VERSION`
- it will display both squashed and merged PR commits

More details in cd413d6a7b8bdcc50255bda2060d1b56063c4b7d