### PR TITLE
add command to install Git LFS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       - hmpps/k8s_setup
       - hmpps/install_helm
       - hmpps/install_aws_cli
+      - hmpps/install_git_lfs
 
 workflows:
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.

--- a/src/commands/install_git_lfs.yml
+++ b/src/commands/install_git_lfs.yml
@@ -1,0 +1,9 @@
+---
+description: Install Git LFS
+steps:
+  - run:
+      name: Install Git LFS
+      command: |
+        curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends git-lfs
+        git lfs install

--- a/src/jobs/build_docker.yml
+++ b/src/jobs/build_docker.yml
@@ -35,7 +35,14 @@ parameters:
   snyk-args:
     type: string
     default: ""
+  git-lfs:
+    type: boolean
+    default: false
 steps:
+  - when:
+      condition: << parameters.git-lfs >>
+      steps:
+        - install_git_lfs
   - checkout
   - setup_remote_docker:
       docker_layer_caching: true


### PR DESCRIPTION
we are using Git LFS in https://github.com/ministryofjustice/hmpps-interventions-ui/ . we need it installed on the image that builds our docker images. this PR adds a command to the orb to install the inderlying library and the git hooks required to properly build our images.

for more information on git lfs see https://github.com/git-lfs/git-lfs