### PR TITLE
[semver:skip] Expand example around npm_security_audit

### DIFF
--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -8,7 +8,9 @@ usage:
   workflows:
     build-test-and-deploy:
       jobs:
-        - hmpps/npm_security_audit
+        - hmpps/npm_security_audit:
+            slack_channel: your_channel_or_leave_out_for_default
+            context: [hmpps-common-vars]
         - hmpps/helm_lint
         - hmpps/build_docker:
             name: build_docker


### PR DESCRIPTION
To make it easier to look up a default configuration

Without the `context` part, the job fails when trying to send the Slack message

<img width="1101" alt="image" src="https://user-images.githubusercontent.com/1526295/125079771-e7f48500-e0bb-11eb-9698-3f37aa1a1e72.png">
