### PR TITLE
Update the deploy job to be able to use `git-crypt`

### DIFF
--- a/src/commands/install_git_crypt.yml
+++ b/src/commands/install_git_crypt.yml
@@ -1,0 +1,8 @@
+---
+description: Install git-crypt
+steps:
+  - run:
+      name: Install git-crypt
+      command: |
+        sudo apt-get update
+        sudo apt-get install -y git-crypt

--- a/src/jobs/deploy_env.yml
+++ b/src/jobs/deploy_env.yml
@@ -42,8 +42,25 @@ parameters:
     type: string
     default: PROJECT_NAME
     description: The Deployment resource's name in Kubernetes to interrogate for the previous deployment's version
+  use_git_crypt:
+    type: boolean
+    default: false
+    description: Use git-crypt to decode encrypted secrets within this repository
+  git_crypt_key:
+    description: Decryption key used by git-crypt (base64 encoded), either the string value, or an environment variable (i.e. $GIT_CRYPT_KEY) that can be read via a context.
+    default: $GIT_CRYPT_KEY
+    type: string
 steps:
   - checkout
+  - when:
+      condition: << parameters.use_git_crypt >>
+      steps:
+        - install_git_crypt
+        - run:
+            name: Decrypt secrets
+            command: |
+              echo "<< parameters.git_crypt_key >>" | base64 -d > git-crypt.key
+              git-crypt unlock git-crypt.key
   - k8s_setup
   - install_helm
   - install_aws_cli

--- a/src/jobs/helm_lint.yml
+++ b/src/jobs/helm_lint.yml
@@ -8,19 +8,38 @@ parameters:
     default: dev
   chart_name:
     type: string
-    default: ${CIRCLE_PROJECT_REPONAME}
+    default: PROJECT_NAME
   helm_dir:
     type: string
     default: helm_deploy
   helm_additional_args:
     type: string
     default: ""
+  use_git_crypt:
+    type: boolean
+    default: false
+    description: Use git-crypt to decode encrypted secrets within this repository
+  git_crypt_key:
+    description: Decryption key used by git-crypt (base64 encoded), either the string value, or an environment variable (i.e. $GIT_CRYPT_KEY) that can be read via a context.
+    default: $GIT_CRYPT_KEY
+    type: string
 steps:
   - checkout
+  - when:
+      condition: << parameters.use_git_crypt >>
+      steps:
+        - install_git_crypt
+        - run:
+            name: Decrypt secrets
+            command: |
+              echo "<< parameters.git_crypt_key >>" | base64 -d > git-crypt.key
+              git-crypt unlock git-crypt.key
   - install_helm
   - run:
       name: Run helm lint
-      command: |
-        helm dependency update << parameters.chart_name >>
-        helm lint << parameters.chart_name >> --values=values-<< parameters.env >>.yaml << parameters.helm_additional_args >>
       working_directory: << parameters.helm_dir >>
+      environment:
+        CHART_NAME: << parameters.chart_name >>
+        ENV_NAME: << parameters.env >>
+        HELM_ADDITIONAL_ARGS: << parameters.helm_additional_args >>
+      command: <<include(scripts/helm_lint.sh)>>

--- a/src/scripts/deploy_env.sh
+++ b/src/scripts/deploy_env.sh
@@ -21,12 +21,16 @@ fi
 # Install/update any chart dependencies.
 helm dependency update "${CHART_NAME}"
 
-HELM_ARGS=(--wait \
-  --install \
-  --reset-values \
-  --timeout 5m \
-  --history-max 10 \
+HELM_ARGS=(--wait
+  --install
+  --reset-values
+  --timeout 5m
+  --history-max 10
   --values "values-${ENV_NAME}.yaml")
+
+if [[ -f "secrets-${ENV_NAME}.yaml" ]]; then
+  HELM_ARGS+=("--values" "secrets-${ENV_NAME}.yaml")
+fi
 
 # Set the image tag for this deployment
 if helm dependency list "${CHART_NAME}" | grep generic-service --silent; then
@@ -35,7 +39,7 @@ else
   HELM_ARGS+=("--set" "image.tag=${APP_VERSION}")
 fi
 
-read -r -a extra_args <<< "${HELM_ADDITIONAL_ARGS}"
+read -r -a extra_args <<<"${HELM_ADDITIONAL_ARGS}"
 
 HELM_ARGS+=("${extra_args[@]}")
 

--- a/src/scripts/helm_lint.sh
+++ b/src/scripts/helm_lint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ ${CHART_NAME} == "PROJECT_NAME" ]]; then
+  CHART_NAME="${CIRCLE_PROJECT_REPONAME}"
+fi
+
+helm dependency update "${CHART_NAME}"
+
+HELM_ARGS=(--values "values-${ENV_NAME}.yaml")
+
+if [[ -f "secrets-${ENV_NAME}.yaml" ]]; then
+  HELM_ARGS+=("--values" "secrets-${ENV_NAME}.yaml")
+fi
+
+read -r -a extra_args <<<"${HELM_ADDITIONAL_ARGS}"
+
+HELM_ARGS+=("${extra_args[@]}")
+
+helm lint "${CHART_NAME}" "${HELM_ARGS[@]}"


### PR DESCRIPTION
This will enable clients to have secrets stored (encrypted) within their repositories and used a deploy time.  The secrets should be stored in files called `secrets-<env>.yaml` alongside the `values-<env>.yaml` files.