### PR TITLE
[semver:minor] Shorten merge-style changelogs

### DIFF
--- a/src/scripts/version_history.sh
+++ b/src/scripts/version_history.sh
@@ -26,6 +26,7 @@ if git rev-parse --quiet --verify "${previous_commit}" &>/dev/null; then
   PAGER="cat" git log --oneline --no-decorate \
     --committer='noreply@github.com' --grep='#' \
     "${previous_commit}..${current_commit}" \
+    | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
     >> .deployment_changelog
 else
   echo "Changelog not available." > .deployment_changelog


### PR DESCRIPTION
Shorten merge-style changelogs by

- Shortening dependabot branch names into a dependabot emoji
- "Merge pull request" → "PR"
- "from ministryofjustice/" → ""

Examples:

**Before**
```
c64e729d Merge pull request #723 from ministryofjustice/dependabot/npm_and_yarn/aws-sdk-2.973.0
24f96ba5 Merge pull request #697 from ministryofjustice/IC-1919-initial-assessment-check-answers
```
![image](https://user-images.githubusercontent.com/1526295/130429261-f7b8408a-6b7f-48b9-bc84-0ddcd5fdcaa2.png)


**After**
```
c64e729d PR #723 :dependabot:npm_and_yarn/aws-sdk-2.973.0
24f96ba5 PR #697 IC-1919-initial-assessment-check-answers
```
![image](https://user-images.githubusercontent.com/1526295/130429296-6fdfdcd3-9409-4906-96b9-648bac8a076f.png)
