### PR TITLE
[semver:patch] Switch to idempotent APP_VERSION generator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ workflows:
           slack_channel_name: dps_alerts_non_prod
           requires:
             - hmpps/build_docker
+            - integration-tests-orb-commands # regression: APP_VERSION persisted in both build_docker and integration-tests-orb-commands causes failure in recall
           context:
             - moj-slack-notifications
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
     docker:
       - image: cimg/base:stable
     steps:
+      - checkout
       - hmpps/create_app_version
       - hmpps/k8s_setup
       - hmpps/install_helm

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,7 +9,7 @@ display:
   source_url: "https://github.com/ministryofjustice/hmpps-circleci-orb"
 
 orbs:
-  mem: circleci/rememborb@0.0.1
+  mem: circleci/rememborb@0.0.2
   aws-cli: circleci/aws-cli@1.2.1
   kubernetes: circleci/kubernetes@0.11.0
   helm: circleci/helm@1.1.2

--- a/src/commands/create_app_version.yml
+++ b/src/commands/create_app_version.yml
@@ -1,20 +1,10 @@
 ---
 description: >
-  Creates an application version string, formatted
-  [DATE].[CIRCLE_BUILD_NUM].[SHORT_SHA1]
-  e.g 2020-04-24.487.fb30e99"
-  Also uses mem/rememborb orb to remember the
-  version as the env var APP_VERSION - which can
+  Creates an application version string and uses mem/rememborb
+  orb to remember the version as the env var APP_VERSION - which can
   be recalled in subsequent steps or jobs e.g. mem/recall
 steps:
-  - run:
-      name: Create app version string
-      command: |
-        DATE=$(date '+%Y-%m-%d')
-        SHORT_SHA1=$(echo $CIRCLE_SHA1 | cut -c1-7)
-        VERSION=${DATE}.${CIRCLE_BUILD_NUM}.${SHORT_SHA1}
-        echo "Created version string: ${VERSION}"
-        echo "export VERSION=$VERSION" >> $BASH_ENV
+  - get_app_version
   - mem/remember:
       env_var: APP_VERSION
-      value: "${VERSION}"
+      value: "${APP_VERSION}"

--- a/src/commands/get_app_version.yml
+++ b/src/commands/get_app_version.yml
@@ -1,0 +1,22 @@
+---
+description: >
+  Creates an application version string, formatted
+  `[CURRENT_DATE].[CircleCI pipeline number].[SHORT_SHA1]`
+  e.g. `2021-08-26.5715.5068cb6a`
+
+  The pipeline number does not change between jobs in the same pipeline,
+  not even if the workflow is re-triggered.
+
+  This means even separate workflows will be able to share the same `APP_VERSION`
+  as long as they're in the same pipeline (`.circleci/config.yml` file) per run
+
+  Note: `scripts/version_history.sh` depends on the 3rd segment to be a git SHA
+steps:
+  - run:
+      name: Generate app version string from commit
+      command: |
+        DATE=$(date '+%Y-%m-%d')
+        SHORT_SHA1="$(git show "$CIRCLE_SHA1" --format='%h' --quiet)"
+        APP_VERSION="$DATE.<< pipeline.number >>.$SHORT_SHA1"
+        echo "Created version string: ${APP_VERSION}"
+        echo "export APP_VERSION=$APP_VERSION" >> $BASH_ENV

--- a/src/jobs/deploy_env.yml
+++ b/src/jobs/deploy_env.yml
@@ -47,8 +47,7 @@ steps:
   - k8s_setup
   - install_helm
   - install_aws_cli
-  - mem/recall:
-      env_var: APP_VERSION
+  - get_app_version
   - when:
       condition: <<parameters.show_changelog>>
       steps:

--- a/src/jobs/sentry_release_and_deploy.yml
+++ b/src/jobs/sentry_release_and_deploy.yml
@@ -16,8 +16,7 @@ parameters:
     description: "Tell sentry-cli to work out the commits on this release - this should only be done ONCE, ideally when you push to DEV."
 steps:
   - checkout
-  - mem/recall:
-      env_var: APP_VERSION
+  - get_app_version
   - run:
       name: Sentry - Setup environment
       command: |


### PR DESCRIPTION
## Overview

This changes the tags on _all_ deployments from
```
2021-09-06.[CI build number].c4caf10
```
to
```
2021-09-06.[CI pipeline number].c4caf10
```
so
- middle component is now the pipeline number, instead of the build number; this number remains the same across all steps and workflows and re-tries
- last component is 7 or **more** characters long, depending on project, because `git show "$CIRCLE_SHA1" --format='%h' --quiet` renders it with as many characters as necessary to reduce collisions -- for hmpps-interventions-service, it's 8 characters long

The pipeline numbers can be viewed on the CircleCI UI here:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/1526295/138097689-02b1d1bc-a74a-4c5d-9b8f-c0a86c068f57.png">

## What does this pull request do?

Makes `APP_VERSION` generation idempotent so it can be used in any number of jobs _without_ memoisation.

The current `CIRCLE_BUILD_NUM` dependency means the generated `APP_VERSION` will be different in each job CircleCI runs in a workflow. So the only way to achieve a consistent `APP_VERSION` is by `mem/recall`ing it.

One of our services builds more than once docker image, and uses APP_VERSION to tag it:

<img width="374" alt="image" src="https://user-images.githubusercontent.com/1526295/132232854-151c88a2-69ec-491d-b1b4-b84aca319517.png">

To achieve this, the `publish_data` job originally had `hmpps/create_app_version` but it lead to [a failure at deploy](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-interventions-service/1421/workflows/e837b067-131a-459f-8340-cb5a5f8fbe3b):
<img width="645" alt="image" src="https://user-images.githubusercontent.com/1526295/132233124-f157a26e-58d7-49e9-b93b-43585647e00a.png">

With the error
<img width="1213" alt="image" src="https://user-images.githubusercontent.com/1526295/132233186-32dda363-73c8-4322-9161-7537470e48c4.png">

(Which is :100:% **correct** because this value should not even be generated more than once. But it doesn't say that; instead, it's an obscure error.)

To work around this, we made the dependencies look like
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/1526295/132234052-723fc112-d5c7-459c-a742-82815e84ee98.png">

My thinking: I can avoid this "recall" problem if the `APP_VERSION` generation can be done any time and does not change between builds

This change swaps `CIRCLE_BUILD_NUM` with `<< pipeline.number >>` which does not change between jobs in the same pipeline. This number is re-used when a workflow is cancelled and re-run and even between workflows on the same pipeline (`.circleci/config.yml` file)

Consequently, `APP_VERSION` will become generatable any time there's git data available, making `mem/recall` unnecessary for those cases.

To facilitate this, the command is now split into:

- `hmpps/get_app_version`, which sets the variable, but does not persist
- `hmpps/create_app_version`, which behaves as before

Net result: we can build docker images in parallel and not worry about recalling creating issues when we have multiple steps requiring APP_VERSION -- and we can generate it before we build a docker image