### PR TITLE
[semver:patch] Bugfix persist env vars between steps

### DIFF
--- a/src/jobs/sentry_release_and_deploy.yml
+++ b/src/jobs/sentry_release_and_deploy.yml
@@ -23,6 +23,8 @@ steps:
       command: |
         export SENTRY_ORG=<< parameters.sentry_org >>
         export SENTRY_PROJECT=<< parameters.sentry_project >>
+        echo "export SENTRY_ORG=$SENTRY_ORG" >> $BASH_ENV
+        echo "export SENTRY_PROJECT=$SENTRY_PROJECT" >> $BASH_ENV
         curl -sL https://sentry.io/get-cli/ | bash
 
   - when:


### PR DESCRIPTION
`SENTRY_ORG` and `SENTRY_PROJECT` were not being persisted between steps
in the build causing errors on all runs.