### PR TITLE
[semver:patch] Allow additional CLI args to be passed to trivy

### DIFF
--- a/src/jobs/trivy_latest_scan.yml
+++ b/src/jobs/trivy_latest_scan.yml
@@ -20,6 +20,10 @@ parameters:
     type: string
     default: HIGH,CRITICAL
     description: What severity of CVE to look for? Options are UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL.
+  additional_args:
+    type: string
+    default: ""
+    description: Additional CLI args to pass into the trivy command
   slack_channel:
     type: string
     default: dps_alerts_security
@@ -41,7 +45,7 @@ steps:
           --no-progress \
           --severity << parameters.cve_severities_to_check >> \
           --ignore-unfixed \
-          "<< parameters.image_name >>:latest"
+          << parameters.additional_args >> "<< parameters.image_name >>:latest"
   - run:
       when: on_fail
       name: Get Trivy results formatted for slack

--- a/src/jobs/trivy_pipeline_scan.yml
+++ b/src/jobs/trivy_pipeline_scan.yml
@@ -11,6 +11,10 @@ parameters:
     type: string
     default: HIGH,CRITICAL
     description: What severity of CVE to look for? Options are UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL.
+  additional_args:
+    type: string
+    default: ""
+    description: Additional CLI args to pass into the trivy command
   docker_version:
     type: string
     default: "20.10.6"
@@ -34,4 +38,4 @@ steps:
           --no-progress \
           --severity << parameters.cve_severities_to_check >> \
           --ignore-unfixed \
-          "${IMAGE_NAME}:${APP_VERSION}"
+          << parameters.additional_args >> "${IMAGE_NAME}:${APP_VERSION}"


### PR DESCRIPTION
This will help solve some of the issues the nodejs apps have been having
with CVEs being detected in the base install of npm (that are not an
issue for their applications).