### PR TITLE
[semver:patch] Show relative merge times in changelog

### DIFF
--- a/src/scripts/version_history.sh
+++ b/src/scripts/version_history.sh
@@ -24,7 +24,7 @@ fi
 # Check $previous_commit sha1 is valid
 if git rev-parse --quiet --verify "${previous_commit}" &>/dev/null; then
   PAGER="cat" git log --oneline --no-decorate \
-    --committer='noreply@github.com' --grep='#' \
+    --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
     "${previous_commit}..${current_commit}" \
     | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
     >> .deployment_changelog


### PR DESCRIPTION
_This is applicable for deploy_env jobs with `show_changelog: true` and `slack_notification: true`_

For example,

```
bbc12fe5 PR #713 cluster-migration/delete-research-environment
083a79a5 PR #712 cluster-migration/add-parallel-dev-deployment
4a8704de PR #703 data/enforce-descriptions
f3882aa6 PR #709 monitoring/make-casenote-errors-contain-ids
d3ad9f21 PR #694 reports/prepare-to-remove-v1-ndmis-report
99903087 PR #699 xHVqOzpw/155-notify-appointment-outcome-feature-flag
```

becomes

```
bbc12fe5 PR #713 cluster-migration/delete-research-environment (2 hours ago)
083a79a5 PR #712 cluster-migration/add-parallel-dev-deployment (18 hours ago)
4a8704de PR #703 data/enforce-descriptions (24 hours ago)
f3882aa6 PR #709 monitoring/make-casenote-errors-contain-ids (24 hours ago)
d3ad9f21 PR #694 reports/prepare-to-remove-v1-ndmis-report (25 hours ago)
99903087 PR #699 xHVqOzpw/155-notify-appointment-outcome-feature-flag (4 days ago)
```

The intent is to make it visible how much delay there is between getting
something to mainline and getting it out on an environment