### PR TITLE
[semver:patch] Bugfix: Use the `follow_timeout` parameter.

### DIFF
--- a/src/jobs/trigger_job.yml
+++ b/src/jobs/trigger_job.yml
@@ -73,7 +73,7 @@ steps:
         - run:
             name: Following pipeline on '<< parameters.vcs_type >>/<< parameters.organization >>/<< parameters.repository >>'
             command: |
-              WAIT=500
+              WAIT=<< parameters.follow_timeout >>
               TIMEOUT=$(expr $SECONDS + $WAIT)
               STOPPED_TIME=null
               BUILD_URL=https://circleci.com/api/v2/pipeline/$BUILD_ID/workflow


### PR DESCRIPTION
This parameter wasn't being used meaning that all triggers were hard
coded to a 500 second timeout.