### PR TITLE
[semver:patch] Allow the setting of no_output_timeout on the docker_build step

### DIFF
--- a/src/jobs/build_docker.yml
+++ b/src/jobs/build_docker.yml
@@ -22,6 +22,10 @@ parameters:
     type: boolean
     default: false
     description: Make the built container image available for subsequent jobs
+  no_output_timeout:
+    type: string
+    default: 10m
+    description: Configure the no_output_timeout setting for the container build step
   snyk-scan:
     type: boolean
     default: false
@@ -68,6 +72,7 @@ steps:
       value: "${IMAGE_NAME}"
   - run:
       name: Build container image
+      no_output_timeout: << parameters.no_output_timeout >>
       command: |
         docker build --pull \
           --rm=false << parameters.dockerfile_dir >> \


### PR DESCRIPTION
This should help teams deal with the gradle slowness we're seeing at the moment.

ref: https://mojdt.slack.com/archives/C69NWE339/p1646727334689739