### PR TITLE
[semver:patch] Increase the helm timeout to 15m by default

### DIFF
--- a/src/scripts/deploy_env.sh
+++ b/src/scripts/deploy_env.sh
@@ -24,7 +24,7 @@ helm dependency update "${CHART_NAME}"
 HELM_ARGS=(--wait \
   --install \
   --reset-values \
-  --timeout 5m \
+  --timeout 15m \
   --history-max 10 \
   --values "values-${ENV_NAME}.yaml")
 


### PR DESCRIPTION
We're migrating one of our services to live and the initial helm upgrade is timing out, this will hopefully fix it.