### PR TITLE
[semver:patch] SDI-189: ✨ Try out buildx for multi arch builds

### DIFF
--- a/src/jobs/build_multiplatform_docker.yml
+++ b/src/jobs/build_multiplatform_docker.yml
@@ -1,0 +1,142 @@
+---
+description: >
+  Build docker image, also creates an app version string and pushes image to repo.
+executor:
+  name: default
+  tag: "3.10"
+parameters:
+  image_name:
+    type: string
+    default: "quay.io/hmpps/${CIRCLE_PROJECT_REPONAME}"
+  dockerfile_dir:
+    type: string
+    default: "."
+  additional_docker_build_args:
+    type: string
+    default: ""
+  docker_version:
+    type: string
+    default: "20.10.11"
+  publish:
+    type: boolean
+    default: true
+  persist_container_image:
+    type: boolean
+    default: false
+    description: Make the built container image available for subsequent jobs
+  no_output_timeout:
+    type: string
+    default: 30m
+    description: Configure the no_output_timeout setting for the container build step
+  snyk-scan:
+    type: boolean
+    default: false
+  snyk-org:
+    type: string
+    default: digital-probation-services
+  snyk-target-file:
+    type: string
+    default: Dockerfile
+  snyk-fail-build:
+    type: boolean
+    default: true
+  snyk-threshold:
+    type: enum
+    enum: ["low", "medium", "high"]
+    default: "high"
+  snyk-args:
+    type: string
+    default: ""
+  git-lfs:
+    type: boolean
+    default: false
+  jira_update:
+    type: boolean
+    default: false
+    description: When true, updates any referenced Jira tickets with build status. Note that Jira integration must be enabled in your CircleCI project settings.
+steps:
+  - when:
+      condition: << parameters.git-lfs >>
+      steps:
+        - install_git_lfs
+  - checkout
+  - setup_remote_docker:
+      docker_layer_caching: true
+      version: << parameters.docker_version >>
+  - create_app_version
+  - run:
+      name: Create IMAGE_NAME env var
+      command: |
+        IMAGE_NAME="<< parameters.image_name >>"
+        echo "export IMAGE_NAME=$IMAGE_NAME" >> $BASH_ENV
+  - mem/remember:
+      env_var: IMAGE_NAME
+      value: "${IMAGE_NAME}"
+  - run:
+      name: Setup buildx
+      command: |
+        docker context create multi-arch-build
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker run --rm --privileged tonistiigi/binfmt --install all
+        docker buildx create --use multi-arch-build --platform linux/arm64,linux/amd64
+  - run:
+      name: Build container image
+      no_output_timeout: << parameters.no_output_timeout >>
+      command: |
+        docker buildx build \
+          --platform linux/amd64,linux/arm64 --pull \
+          --progress plain \
+          --rm=false << parameters.dockerfile_dir >> \
+          --build-arg BUILD_NUMBER=$APP_VERSION \
+          --build-arg GIT_REF=$CIRCLE_SHA1 \
+          --tag "${IMAGE_NAME}:${APP_VERSION}" \
+          --label "maintainer=dps-hmpps@digital.justice.gov.uk" \
+          --label "app.version=${APP_VERSION}" \
+          --label "build.version=${APP_VERSION}" \
+          --label "build.number=${CIRCLE_BUILD_NUM}" \
+          --label "build.url=${CIRCLE_BUILD_URL}" \
+          --label "build.gitref=${CIRCLE_SHA1}" \
+          << parameters.additional_docker_build_args >>
+
+  - when:
+      condition: << parameters.persist_container_image >>
+      steps:
+        - run:
+            name: Persist container image to workspace
+            command: |
+              mkdir -p docker_cache
+              docker save ${IMAGE_NAME}:${APP_VERSION} -o docker_cache/build_image.tar
+        - persist_to_workspace:
+            root: ~/app
+            paths:
+              - docker_cache
+
+  - when:
+      condition: << parameters.snyk-scan >>
+      steps:
+        - snyk/scan:
+            project: "${CIRCLE_PROJECT_REPONAME}-docker"
+            organization: << parameters.snyk-org >>
+            docker-image-name: "${IMAGE_NAME}:${APP_VERSION}"
+            target-file: << parameters.dockerfile_dir >>/<< parameters.snyk-target-file >>
+            severity-threshold: << parameters.snyk-threshold >>
+            fail-on-issues: << parameters.snyk-fail-build >>
+            additional-arguments: << parameters.snyk-args >>
+            monitor-on-build: << parameters.publish >>
+
+  - when:
+      condition: <<parameters.publish>>
+      steps:
+        - run:
+            name: Publish image to repository
+            command: |
+              #push to quay.io
+              docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io
+              docker tag "<< parameters.image_name >>:${APP_VERSION}" "<< parameters.image_name >>:latest"
+              docker push "<< parameters.image_name >>:${APP_VERSION}"
+              docker push "<< parameters.image_name >>:latest"
+
+  - when:
+      condition: << parameters.jira_update >>
+      steps:
+        - jira/notify


### PR DESCRIPTION
Copy of the docker build to try out the multi platform.  Not sure if we want to introduce for all builds, will trial first.
```
 diff build_docker.yml build_multiplatform_docker.yml
19c19
<     default: "20.10.6"
---
>     default: "20.10.11"
75a76,82
>       name: Setup buildx
>       command: |
>         docker context create multi-arch-build
>         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
>         docker run --rm --privileged tonistiigi/binfmt --install all
>         docker buildx create --use multi-arch-build --platform linux/arm64,linux/amd64
>   - run:
79c86,88
<         docker build --pull \
---
>         docker buildx build \
>           --platform linux/amd64,linux/arm64 --pull \
>           --progress plain \
```