### PR TITLE
[semver:minor] Allow the version of the node executor for npm_security_audit to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ We welcome [issues](https://github.com/ministryofjustice/hmpps-circleci-orb/issu
 
 To publish a new production version:
 * Create a PR to the `Alpha` branch with your changes. This will act as a "staging" branch.
-* When ready to publish a new production version, create a PR from `Alpha` to `master`. The Git Subject should include `[semver:patch|minor|release|skip]` to indicate the type of release.
+* When ready to publish a new production version, create a PR from `Alpha` to `master`. The Git Subject (commit message of the most recent commit - `git log -1 --pretty=%s.`) should include `[semver:patch|minor|release|skip]` to indicate the type of release.
 * On merge, the release will be published to the orb registry automatically.
 
 For further questions/comments about this or other orbs, visit the Orb Category of [CircleCI Discuss](https://discuss.circleci.com/c/orbs).

--- a/src/jobs/npm_security_audit.yml
+++ b/src/jobs/npm_security_audit.yml
@@ -3,13 +3,13 @@ description: >
   Node.js projects using npm - auditing package dependencies for security vulnerabilities
 executor:
   name: node
-  tag: <<parameters.node_version>>
+  tag: <<parameters.node_tag>>
 parameters:
   slack_channel:
     type: string
     default: dps_alerts_security
     description: Slack channel to use for notifications.
-  node_version:
+  node_tag:
     type: string
     default: "16.15"
 steps:

--- a/src/jobs/npm_security_audit.yml
+++ b/src/jobs/npm_security_audit.yml
@@ -3,12 +3,15 @@ description: >
   Node.js projects using npm - auditing package dependencies for security vulnerabilities
 executor:
   name: node
-  tag: "16.15"
+  tag: <<parameters.node_version>>
 parameters:
   slack_channel:
     type: string
     default: dps_alerts_security
     description: Slack channel to use for notifications.
+  node_version:
+    type: string
+    default: "16.15"
 steps:
   - checkout
   - restore_cache:


### PR DESCRIPTION
This will allow us to fix this failing build:

https://app.circleci.com/pipelines/github/ministryofjustice/wmt-web/1644/workflows/c5883171-0154-4ff0-bc3d-d9a80ec73554/jobs/9288