### PR TITLE
[semver:release] SDI-411 Use default docker version

### DIFF
--- a/src/commands/veracode_prepare_artifacts.yml
+++ b/src/commands/veracode_prepare_artifacts.yml
@@ -7,13 +7,9 @@ parameters:
     description: Directory inside the docker image where the application artifacts are saved
     type: string
     default: "/app"
-  docker_version:
-    type: string
-    default: "20.10.14"
 steps:
   - setup_remote_docker:
       docker_layer_caching: true
-      version: << parameters.docker_version >>
   - checkout
   - run:
       name: Build temp docker image and copy app files

--- a/src/jobs/build_docker.yml
+++ b/src/jobs/build_docker.yml
@@ -14,9 +14,6 @@ parameters:
   additional_docker_build_args:
     type: string
     default: ""
-  docker_version:
-    type: string
-    default: "20.10.14"
   publish:
     type: boolean
     default: true
@@ -62,7 +59,6 @@ steps:
   - checkout
   - setup_remote_docker:
       docker_layer_caching: true
-      version: << parameters.docker_version >>
   - create_app_version
   - run:
       name: Create IMAGE_NAME env var

--- a/src/jobs/build_multiplatform_docker.yml
+++ b/src/jobs/build_multiplatform_docker.yml
@@ -14,9 +14,6 @@ parameters:
   additional_docker_build_args:
     type: string
     default: ""
-  docker_version:
-    type: string
-    default: "20.10.14"
   no_output_timeout:
     type: string
     default: 30m
@@ -55,7 +52,6 @@ steps:
   - checkout
   - setup_remote_docker:
       docker_layer_caching: true
-      version: << parameters.docker_version >>
   - create_app_version
   - run:
       name: Create IMAGE_NAME env var

--- a/src/jobs/publish_docker.yml
+++ b/src/jobs/publish_docker.yml
@@ -11,13 +11,9 @@ parameters:
   publish_latest_tag:
     type: boolean
     default: true
-  docker_version:
-    type: string
-    default: "20.10.14"
 steps:
   - checkout
-  - setup_remote_docker:
-      version: << parameters.docker_version >>
+  - setup_remote_docker
   - recall_container_image
   - run:
       name: Publish image to repository

--- a/src/jobs/trivy_latest_scan.yml
+++ b/src/jobs/trivy_latest_scan.yml
@@ -12,9 +12,6 @@ parameters:
   image_name:
     type: string
     default: "quay.io/hmpps/${CIRCLE_PROJECT_REPONAME}"
-  docker_version:
-    type: string
-    default: "20.10.14"
   trivy_template:
     type: string
     default: <<include(files/trivy.tpl)>>
@@ -36,8 +33,7 @@ parameters:
     description: Slack channel to use for notifications.
 steps:
   - checkout
-  - setup_remote_docker:
-      version: << parameters.docker_version >>
+  - setup_remote_docker
   - install_trivy
   - restore_cache:
       key: trivy_cache_<< parameters.cache_key >>

--- a/src/jobs/trivy_pipeline_scan.yml
+++ b/src/jobs/trivy_pipeline_scan.yml
@@ -21,13 +21,9 @@ parameters:
     type: string
     default: v1
     description: Cache key for the vulnerability database - change to break the cache.
-  docker_version:
-    type: string
-    default: "20.10.14"
 steps:
   - checkout
-  - setup_remote_docker:
-      version: << parameters.docker_version >>
+  - setup_remote_docker
   - recall_container_image
   - install_trivy
   - restore_cache:


### PR DESCRIPTION
Circle have recommended we use the default (i.e. latest) version of docker when using the setup_remote_docker step. Details in this post: https://discuss.circleci.com/t/setup-remote-docker-architecture-change/45303.

As we are removing a parameter this change is breaking, hence a major version upgrade.