### PR TITLE
[semver:minor] INC-1226: add param for JDK executor version for owasp job

### DIFF
--- a/src/jobs/gradle_owasp_dependency_check.yml
+++ b/src/jobs/gradle_owasp_dependency_check.yml
@@ -3,7 +3,7 @@ description: >
   Job for running OWASP Dependency Check, looking for package dependencies with security vulnerabilities
 executor:
   name: java
-  tag: "17.0"
+  tag: <<parameters.jdk_tag>>
 parameters:
   cve_data_directory:
     description: The plugin database directory.
@@ -29,6 +29,9 @@ parameters:
     type: string
     default: dps_alerts_security
     description: Slack channel to use for notifications.
+  jdk_tag:
+    default: "17.0"
+    type: string
 steps:
   - checkout
   - gradle/with_cache:


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/INC-1226

Since upgrading [hmpps-incentives-api](https://github.com/ministryofjustice/hmpps-incentives-api) to Gradle 8 we were seeing the `hmpps/gradle_owasp_dependency_check` job fail with the following error (see [example](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-incentives-api/1860/workflows/8808b70a-e9bd-49ed-b558-e25988eeb5cc/jobs/6855/parallel-runs/0/steps/0-108)):
```
* What went wrong:
Execution failed for task ':dependencyCheckAnalyze'.
> Could not resolve all dependencies for configuration ':agentDeps'.
   > Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
      > No matching toolchains found for requested specification: {languageVersion=19, vendor=any, implementation=vendor-specific}.
         > No locally installed toolchains match (see https://docs.gradle.org/8.1/userguide/toolchains.html#sec:auto_detection) and toolchain download repositories have not been configured (see https://docs.gradle.org/8.1/userguide/toolchains.html#sub:download_repositories).
```

This PR allows folks to specify the JDK version, for example `"19.0"`, then the job runs successfully