### PR TITLE
[semver:patch]: 🔧 Always send slack release notifications to central channel, optionally also send to team channel

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -13,7 +13,7 @@ orbs:
   aws-cli: circleci/aws-cli@1.2.1
   kubernetes: circleci/kubernetes@1.3.0
   helm: circleci/helm@1.2.0
-  slack: circleci/slack@4.8.3
+  slack: circleci/slack@4.12.5
   snyk: snyk/snyk@1.1.2
   gradle: circleci/gradle@2.2.0
   owasp: entur/owasp@0.0.17

--- a/src/jobs/deploy_env.yml
+++ b/src/jobs/deploy_env.yml
@@ -31,7 +31,7 @@ parameters:
     description: When true, notifies a Slack channel after every deployment done with this job.
   slack_channel_name:
     type: string
-    default: dps-releases
+    default: "dps-releases"
     description: Slack channel to use for deployment notifications.
   helm_additional_args:
     type: string
@@ -106,9 +106,27 @@ steps:
   - when:
       condition: <<parameters.slack_notification>>
       steps:
+        - run:
+            name: Slack channels to notify
+            command: |
+              # For prod releases only always notify central dps-releases channel in addition to custom team channels.
+              if [[ "<< parameters.env >>" == "prod" ]] || [[ "<< parameters.env >>" == "production" ]]; then
+                # By default send to channel ID CVA3MKDTR = #dps-releases
+                if [[ "<< parameters.slack_channel_name >>" == "CVA3MKDTR" ]] || [[ "<< parameters.slack_channel_name >>" == "dps-releases" ]]; then
+                  export NOTIFY_SLACK_CHANNELS="CVA3MKDTR"
+                else
+                  # Also send to custom team channel
+                  export NOTIFY_SLACK_CHANNELS="CVA3MKDTR,<< parameters.slack_channel_name >>"
+                fi
+              else
+                # non prod env, send to custom team channel.
+                export NOTIFY_SLACK_CHANNELS="<< parameters.slack_channel_name >>"
+              fi
+              echo "export NOTIFY_SLACK_CHANNELS=$NOTIFY_SLACK_CHANNELS" >> $BASH_ENV
         - slack/notify:
             event: always
-            channel: << parameters.slack_channel_name >>
+            #Always send to HMPPS releases channel, plus team channel
+            channel: ${NOTIFY_SLACK_CHANNELS}
             custom: |
               {
                 "blocks": [

--- a/src/jobs/deploy_env.yml
+++ b/src/jobs/deploy_env.yml
@@ -125,7 +125,6 @@ steps:
               echo "export NOTIFY_SLACK_CHANNELS=$NOTIFY_SLACK_CHANNELS" >> $BASH_ENV
         - slack/notify:
             event: always
-            #Always send to HMPPS releases channel, plus team channel
             channel: ${NOTIFY_SLACK_CHANNELS}
             custom: |
               {

--- a/src/jobs/deploy_env.yml
+++ b/src/jobs/deploy_env.yml
@@ -110,17 +110,17 @@ steps:
             name: Slack channels to notify
             command: |
               # For prod releases only always notify central dps-releases channel in addition to custom team channels.
-              if [[ "<< parameters.env >>" == "prod" ]] || [[ "<< parameters.env >>" == "production" ]]; then
+              if [[ "<< parameters.env >>" == "prod" || "<< parameters.env >>" == "production" ]]; then
                 # By default send to channel ID CVA3MKDTR = #dps-releases
-                if [[ "<< parameters.slack_channel_name >>" == "CVA3MKDTR" ]] || [[ "<< parameters.slack_channel_name >>" == "dps-releases" ]]; then
-                  export NOTIFY_SLACK_CHANNELS="CVA3MKDTR"
+                if [[ "<< parameters.slack_channel_name >>" == "CVA3MKDTR" || "<< parameters.slack_channel_name >>" == "dps-releases" ]]; then
+                  NOTIFY_SLACK_CHANNELS="CVA3MKDTR"
                 else
                   # Also send to custom team channel
-                  export NOTIFY_SLACK_CHANNELS="CVA3MKDTR,<< parameters.slack_channel_name >>"
+                  NOTIFY_SLACK_CHANNELS="CVA3MKDTR,<< parameters.slack_channel_name >>"
                 fi
               else
-                # non prod env, send to custom team channel.
-                export NOTIFY_SLACK_CHANNELS="<< parameters.slack_channel_name >>"
+                # non prod envs, send to custom team channel.
+                NOTIFY_SLACK_CHANNELS="<< parameters.slack_channel_name >>"
               fi
               echo "export NOTIFY_SLACK_CHANNELS=$NOTIFY_SLACK_CHANNELS" >> $BASH_ENV
         - slack/notify:


### PR DESCRIPTION
This change ensures we always get release notifications for production environments sent to the slack channel `dps-releases`.  If a team has set a channel other than this, then that channel will be notified also.