### PR TITLE
[semver:minor] SDIT-1430: 🔧 Switch deploy to run

### DIFF
--- a/src/jobs/deploy_env.yml
+++ b/src/jobs/deploy_env.yml
@@ -91,7 +91,7 @@ steps:
               echo "export DEPLOYMENT_CHANGELOG_JSON=$(echo -n "$DEPLOYMENT_CHANGELOG" | tr '"' "'" | tr "\`" "'" | jq -Rs)" >> $BASH_ENV
   - mem/recall:
       env_var: APP_VERSION
-  - deploy:
+  - run:
       name: Deploy to << parameters.env >>
       working_directory: << parameters.helm_dir >>
       environment:


### PR DESCRIPTION
We currently get the message
> This job is using a deprecated deploy step, please [update .circleci/config.yml](https://circleci.com/docs/migrate-from-deploy-to-run/) to use a run step
in our pipelines, simple change