### PR TITLE
[semver:minor]: Add postgres_db parameter to java_localstack_postgres executor

### DIFF
--- a/src/executors/java_localstack_postgres.yml
+++ b/src/executors/java_localstack_postgres.yml
@@ -16,6 +16,7 @@ docker:
     environment:
       - POSTGRES_PASSWORD=<< parameters.postgres_password >>
       - POSTGRES_USER=<< parameters.postgres_username >>
+      - POSTGRES_DB=<< parameters.postgres_db >>
 environment:
   _JAVA_OPTIONS: <<parameters.java_options>>
 working_directory: ~/app
@@ -41,6 +42,9 @@ parameters:
     type: string
   postgres_username:
     default: "root"
+    type: string
+  postgres_db:
+    default: "postgres"
     type: string
   java_options:
     default: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1


### PR DESCRIPTION
Add postgres_db parameter to java_localstack_postgres executor, so it can create postgres container same as java_postgres and node_redis_postgres.