### PR TITLE
[semver:minor] Add --name attribute to docker buildx create command to fix docker layer caching errors

### DIFF
--- a/release-notes/9.x.md
+++ b/release-notes/9.x.md
@@ -1,3 +1,7 @@
+# 9.2.0
+Add --name attribute to the build_multiplatform_docker job `docker buildx create` step, to fix an issue with having
+docker layer cache enabled with docker buildx command, but not correctly setting the name.
+
 # 9.1.0
 
 Allow `jdk_tag` to be passed through to veracode jobs, rather than hardcoding java 17.

--- a/src/jobs/build_multiplatform_docker.yml
+++ b/src/jobs/build_multiplatform_docker.yml
@@ -75,7 +75,7 @@ steps:
         docker context create multi-arch-build
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         docker run --rm --privileged tonistiigi/binfmt --install all
-        docker buildx create --use multi-arch-build --platform linux/arm64,linux/amd64
+        docker buildx create --use multi-arch-build --platform linux/arm64,linux/amd64 --name "${IMAGE_NAME}:${APP_VERSION}"
   - run:
       name: quay.io login
       command: docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io


### PR DESCRIPTION
Some circle-ci builds are getting errors relating to docker layer caching. After raising a ticket request with the circle ci team they suggested adding a --name attribute to the docker buildx create command, to fix this.

## Additional Info
Ticket: https://support.circleci.com/hc/en-us/requests/152193?page=1

Response
--
Hi Aaron,
 
As an additional follow up to Henna's previous message, I'd like to bring up a few points regarding your use of buildx
When using buildx, we recommend in our documentation that builders are --named in order to successfully work with DLC.
Documentation: https://circleci.com/docs/docker-layer-caching/#buildx-builder-instances