### PR TITLE
 [semver:minor] Add "--name" attribute to build_multiplatform_docker job buildx step

### DIFF
--- a/release-notes/9.x.md
+++ b/release-notes/9.x.md
@@ -1,3 +1,7 @@
+# 9.4.0
+Re-introduce the --name attribute previously added in version 9.2.0 to fix an issue with having
+docker layer cache enabled not working as intended with buildx command.
+
 # 9.3.0
 
 Revert 9.2.0 due to Circle error `name needs to start with a letter and may not contain symbols, except ._-`

--- a/src/jobs/build_multiplatform_docker.yml
+++ b/src/jobs/build_multiplatform_docker.yml
@@ -75,7 +75,7 @@ steps:
         docker context create multi-arch-build
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         docker run --rm --privileged tonistiigi/binfmt --install all
-        docker buildx create --use multi-arch-build --platform linux/arm64,linux/amd64
+        docker buildx create --use multi-arch-build --platform linux/arm64,linux/amd64 --name="${CIRCLE_PROJECT_REPONAME}"
   - run:
       name: quay.io login
       command: docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io


### PR DESCRIPTION
Without this attribute the docker layer cache which is enabled, will not function correctly. As it requires a name for the build context to find cached layers, without it, a random name is generated every time and nothing is ever cached.

Also update release notes to document changes.