### PR TITLE
[semver:minor] Add value for environment to helm args - used by prometheus alert rules for better filtering

### DIFF
--- a/src/scripts/deploy_env.sh
+++ b/src/scripts/deploy_env.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 if [[ ${RELEASE_NAME} == "PROJECT_NAME_ENV_NAME" ]]; then

--- a/src/scripts/deploy_env.sh
+++ b/src/scripts/deploy_env.sh
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env bash
 
 if [[ ${RELEASE_NAME} == "PROJECT_NAME_ENV_NAME" ]]; then
@@ -26,7 +27,8 @@ HELM_ARGS=(--wait \
   --reset-values \
   --timeout "${HELM_TIMEOUT}" \
   --history-max 10 \
-  --values "values-${ENV_NAME}.yaml")
+  --values "values-${ENV_NAME}.yaml" \
+  --set "global.environment=${ENV_NAME}")
 
 # See https://github.com/ministryofjustice/hmpps-ip-allowlists
 if [[ -n ${IP_ALLOWLIST_GROUPS_YAML} ]]; then


### PR DESCRIPTION
Adding extra helm value to help track enviroments - this value is going to be picked up by generic-prometheus-alerts chart and enable better filtering of alerts based on environment.  See https://github.com/ministryofjustice/hmpps-helm-charts/pull/175 
